### PR TITLE
Update README.md

### DIFF
--- a/4_accelerators/README.md
+++ b/4_accelerators/README.md
@@ -8,4 +8,4 @@ This section provides sample implementations of some of the patterns as ready to
 
 - :rocket: [Retrieval Augmented Generation (RAG) Accelerator](01-rag-agent/README.md)
 - :rocket: [Code Generation Agent Accelerator](02-code-generation-agent/README.md)
-- :rocket: [Multi-domain Agent Accelerator](03-multi-domain-agents/automating_analytics/README.md)
+- :rocket: [Multi-domain Agent Accelerator](03-multi-domain-agents//travel_leisure/README.md)


### PR DESCRIPTION
This pull request updates the `4_accelerators/README.md` file to correct the link for the Multi-domain Agent Accelerator.

* Updated the link for the Multi-domain Agent Accelerator to point to the correct `travel_leisure` directory instead of `automating_analytics` in the `4_accelerators/README.md` file.Fix broken link